### PR TITLE
Simple optimizations

### DIFF
--- a/lib/rule_engine/__init__.py
+++ b/lib/rule_engine/__init__.py
@@ -30,7 +30,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-__version__ = '3.6.1'
+__version__ = '3.6.2'
 
 from .engine import resolve_attribute
 from .engine import resolve_item


### PR DESCRIPTION
Two optimizations:
* Don't recurse into dicts for coerce_value
* Early break once more than one type is found when checking iterable types